### PR TITLE
feature / tests improvements

### DIFF
--- a/lib/event_manager_web/types/event.ex
+++ b/lib/event_manager_web/types/event.ex
@@ -11,7 +11,7 @@ defmodule EventManagerWeb.Types.Event do
     field(:title, non_null(:string))
     field(:description, non_null(:string))
     field(:location, non_null(:string))
-    field(:public, :boolean, default_value: false)
+    # field(:public, :boolean, default_value: false)
     field(:start_time, non_null(:datetime))
     field(:end_time, non_null(:datetime))
   end
@@ -29,7 +29,7 @@ defmodule EventManagerWeb.Types.Event do
     field(:title, non_null(:string))
     field(:description, non_null(:string))
     field(:location, non_null(:string))
-    field(:public, non_null(:boolean))
+    # field(:public, non_null(:boolean))
     field(:status, non_null(:event_state))
     field(:start_time, non_null(:datetime))
     field(:end_time, non_null(:datetime))

--- a/test/event_manager/events_test.exs
+++ b/test/event_manager/events_test.exs
@@ -13,13 +13,13 @@ defmodule EventManager.EventsTest do
       public: true,
       status: :draft,
       start_time:
-        NaiveDateTime.utc_now()
-        |> NaiveDateTime.truncate(:second)
-        |> NaiveDateTime.to_iso8601(),
+        DateTime.utc_now()
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601(),
       end_time:
-        NaiveDateTime.utc_now()
-        |> NaiveDateTime.truncate(:second)
-        |> NaiveDateTime.to_iso8601()
+        DateTime.utc_now()
+        |> DateTime.truncate(:second)
+        |> DateTime.to_iso8601()
     }
 
     @update_attrs %{

--- a/test/event_manager_web/integrations/event_test.exs
+++ b/test/event_manager_web/integrations/event_test.exs
@@ -12,7 +12,6 @@ defmodule EventManagerWeb.Schema.EventTest do
     endTime
     startTime
     status
-    public
     location
   """
 
@@ -31,7 +30,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         "description" => "Test",
         "title" => "test",
         "location" => "here",
-        "public" => true,
         "startTime" =>
           DateTime.utc_now()
           |> DateTime.truncate(:second)
@@ -51,7 +49,6 @@ defmodule EventManagerWeb.Schema.EventTest do
                    "description" => description,
                    "endTime" => end_time,
                    "location" => location,
-                   "public" => public,
                    "startTime" => start_time,
                    "status" => "DRAFT",
                    "title" => title
@@ -62,7 +59,6 @@ defmodule EventManagerWeb.Schema.EventTest do
       assert description == event["description"]
       assert end_time == event["endTime"]
       assert location == event["location"]
-      assert public == event["public"]
       assert start_time == event["startTime"]
       assert title == event["title"]
     end
@@ -80,7 +76,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         description: "Test",
         title: "test",
         location: "here",
-        public: true,
         status: :draft,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -96,7 +91,6 @@ defmodule EventManagerWeb.Schema.EventTest do
                    "description" => description,
                    "endTime" => end_time,
                    "location" => location,
-                   "public" => public,
                    "startTime" => start_time,
                    "status" => "DRAFT",
                    "title" => title
@@ -107,7 +101,6 @@ defmodule EventManagerWeb.Schema.EventTest do
       assert title == event.title
       assert description == event.description
       assert location == event.location
-      assert public == event.public
       assert end_time == event.end_time |> DateTime.to_iso8601()
       assert start_time == event.start_time |> DateTime.to_iso8601()
     end
@@ -145,7 +138,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         description: "Test",
         title: "test",
         location: "here",
-        public: true,
         status: :draft,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -165,7 +157,6 @@ defmodule EventManagerWeb.Schema.EventTest do
                    "description" => description,
                    "endTime" => end_time,
                    "location" => location,
-                   "public" => public,
                    "startTime" => start_time,
                    "status" => "DRAFT",
                    "title" => title
@@ -176,7 +167,6 @@ defmodule EventManagerWeb.Schema.EventTest do
       assert title == event.title
       assert description == event.description
       assert location == event.location
-      assert public == event.public
       assert end_time == event.end_time |> DateTime.to_iso8601()
       assert start_time == event.start_time |> DateTime.to_iso8601()
     end
@@ -188,7 +178,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         description: "Test",
         title: "test",
         location: "here",
-        public: true,
         status: :published,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -242,7 +231,6 @@ defmodule EventManagerWeb.Schema.EventTest do
           description: "Test1",
           title: "test1",
           location: "here",
-          public: true,
           status: :draft,
           start_time: DateTime.utc_now() |> DateTime.truncate(:second),
           end_time: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -251,7 +239,6 @@ defmodule EventManagerWeb.Schema.EventTest do
           description: "Test2",
           title: "test2",
           location: "here",
-          public: true,
           status: :draft,
           start_time: DateTime.utc_now() |> DateTime.truncate(:second),
           end_time: DateTime.utc_now() |> DateTime.truncate(:second)

--- a/test/event_manager_web/integrations/event_test.exs
+++ b/test/event_manager_web/integrations/event_test.exs
@@ -312,7 +312,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         description: "Test",
         title: "test",
         location: "here",
-        public: true,
         status: :draft,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -332,7 +331,6 @@ defmodule EventManagerWeb.Schema.EventTest do
                    "description" => description,
                    "endTime" => end_time,
                    "location" => location,
-                   "public" => public,
                    "startTime" => start_time,
                    "status" => "PUBLISHED",
                    "title" => title
@@ -343,7 +341,6 @@ defmodule EventManagerWeb.Schema.EventTest do
       assert title == event.title
       assert description == event.description
       assert location == event.location
-      assert public == event.public
       assert end_time == event.end_time |> DateTime.to_iso8601()
       assert start_time == event.start_time |> DateTime.to_iso8601()
     end
@@ -355,7 +352,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         description: "Test",
         title: "test",
         location: "here",
-        public: true,
         status: :ended,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -416,7 +412,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         description: "Test",
         title: "test",
         location: "here",
-        public: true,
         status: :published,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)
@@ -436,7 +431,6 @@ defmodule EventManagerWeb.Schema.EventTest do
                    "description" => description,
                    "endTime" => end_time,
                    "location" => location,
-                   "public" => public,
                    "startTime" => start_time,
                    "status" => "CANCELLED",
                    "title" => title
@@ -447,7 +441,6 @@ defmodule EventManagerWeb.Schema.EventTest do
       assert title == event.title
       assert description == event.description
       assert location == event.location
-      assert public == event.public
       assert end_time == event.end_time |> DateTime.to_iso8601()
       assert start_time == event.start_time |> DateTime.to_iso8601()
     end
@@ -459,7 +452,6 @@ defmodule EventManagerWeb.Schema.EventTest do
         description: "Test",
         title: "test",
         location: "here",
-        public: true,
         status: :ended,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)


### PR DESCRIPTION
Hide `public` field from Event type because private events aren't supported yet.

In tests:

- Remove lines testing for the `public` field.
- Switch to DateTime because we need the time zone