### PR TITLE
feature / scope published events

### DIFF
--- a/lib/event_manager/events.ex
+++ b/lib/event_manager/events.ex
@@ -25,9 +25,7 @@ defmodule EventManager.Events do
       [%Event{}, ...]
 
   """
-  def list_events do
-    Repo.all(Event)
-  end
+  def list_events, do: Repo.all(Event)
 
   @doc """
   Returns a list of only published events.
@@ -40,7 +38,7 @@ defmodule EventManager.Events do
   """
   def list_published_events do
     Event
-    |> do_where_published()
+    |> where_published()
     |> Repo.all()
   end
 
@@ -71,15 +69,10 @@ defmodule EventManager.Events do
   """
   def list_published_events(limit, offset) do
     Event
-    |> do_where_published()
+    |> where_published()
     |> limit(^limit)
     |> offset(^offset)
     |> Repo.all()
-  end
-
-  defp do_where_published(queryable) do
-    queryable
-    |> where([q], q.status in ["published", "participations_closed"])
   end
 
   @doc """
@@ -191,5 +184,9 @@ defmodule EventManager.Events do
   def get_event_creator(%Event{} = event) do
     Ecto.assoc(event, :creator)
     |> Repo.one!()
+  end
+
+  defp where_published(queryable) do
+    where(queryable, [q], q.status in ["published", "participations_closed"])
   end
 end

--- a/lib/event_manager/events.ex
+++ b/lib/event_manager/events.ex
@@ -108,6 +108,46 @@ defmodule EventManager.Events do
   def get_event(id), do: Repo.get(Event, id)
 
   @doc """
+  Gets a single published event.
+
+  Raises `Ecto.NoResultsError` if it doesn't exist or it isn't published.
+
+  ## Examples
+
+      iex> get_event!(123)
+      %Event{}
+
+      iex> get_event!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_published_event!(id) do
+    Event
+    |> where_published()
+    |> Repo.get!(id)
+  end
+
+  @doc """
+  Gets a single event.
+
+  Returns `nil` if it doesn't exist or it isn't published.
+
+  ## Examples
+
+      iex> get_event(123)
+      %Event{}
+
+      iex> get_event(456)
+      nil
+
+  """
+  def get_published_event(id) do
+    Event
+    |> where_published()
+    |> Repo.get(id)
+  end
+
+  @doc """
   Creates a event.
 
   ## Examples

--- a/lib/event_manager/events.ex
+++ b/lib/event_manager/events.ex
@@ -30,18 +30,56 @@ defmodule EventManager.Events do
   end
 
   @doc """
+  Returns a list of only published events.
+
+  ## Examples
+
+      iex> list_published_events()
+      [%Event{}, ...]
+
+  """
+  def list_published_events do
+    Event
+    |> do_where_published()
+    |> Repo.all()
+  end
+
+  @doc """
   Returns the paginated list of events.
 
   ## Examples
 
       iex> list_events(10, 1)
       [%Event{}, ...]
+
   """
   def list_events(limit, offset) do
     Event
     |> limit(^limit)
     |> offset(^offset)
     |> Repo.all()
+  end
+
+  @doc """
+  Returns a list of only published events.
+
+  ## Examples
+
+      iex> list_published_events(10, 1)
+      [%Event{}, ...]
+
+  """
+  def list_published_events(limit, offset) do
+    Event
+    |> do_where_published()
+    |> limit(^limit)
+    |> offset(^offset)
+    |> Repo.all()
+  end
+
+  defp do_where_published(queryable) do
+    queryable
+    |> where([q], q.status in ["published", "participations_closed"])
   end
 
   @doc """

--- a/lib/event_manager_web/resolvers/events.ex
+++ b/lib/event_manager_web/resolvers/events.ex
@@ -14,7 +14,7 @@ defmodule EventManagerWeb.Resolvers.Events do
                 |> Keyword.get(:max_per_page, 50)
 
   def get_event(params, _info) do
-    do_get_event(params, &Events.get_event/1)
+    do_get_event(params, &Events.get_published_event/1)
   end
 
   def events(args, _info) do

--- a/lib/event_manager_web/resolvers/events.ex
+++ b/lib/event_manager_web/resolvers/events.ex
@@ -20,7 +20,7 @@ defmodule EventManagerWeb.Resolvers.Events do
   def events(args, _info) do
     case Connection.offset_and_limit_for_query(args, max: @max_per_page) do
       {:ok, offset, limit} ->
-        Events.list_events(limit, offset) |> Connection.from_slice(offset)
+        Events.list_published_events(limit, offset) |> Connection.from_slice(offset)
 
       {:error,
        "You must supply a count (total number of records) option if using `last` without `before`"} ->

--- a/lib/event_manager_web/types/event.ex
+++ b/lib/event_manager_web/types/event.ex
@@ -22,6 +22,7 @@ defmodule EventManagerWeb.Types.Event do
     value(:published, description: "Event is published")
     value(:ended, description: "Event has ended")
     value(:cancelled, description: "Event has been cancelled")
+    value(:participations_closed, description: "Participations submit is no longer allowed")
   end
 
   object(:event) do

--- a/test/event_manager_web/integrations/event_test.exs
+++ b/test/event_manager_web/integrations/event_test.exs
@@ -79,6 +79,7 @@ defmodule EventManagerWeb.Schema.EventTest do
       )
       |> Enum.map(&Event.changeset/1)
       |> Enum.map(&EventManager.Repo.insert!/1)
+      |> Enum.into(%{}, fn event -> {event.status, event} end)
     end
 
     @query """
@@ -90,7 +91,7 @@ defmodule EventManagerWeb.Schema.EventTest do
     @statuses ~w(draft published cancelled participations_closed)a
 
     test "doesn't find a drafted event" do
-      [draft | _others] = events_by_statuses(@statuses)
+      %{draft: draft} = events_by_statuses(@statuses)
 
       {:ok, result} = Absinthe.run(@query, @schema, variables: %{"id" => draft.id})
 
@@ -98,7 +99,7 @@ defmodule EventManagerWeb.Schema.EventTest do
     end
 
     test "finds a publish event" do
-      [_, published, _, _] = events_by_statuses(@statuses)
+      %{published: published} = events_by_statuses(@statuses)
 
       {:ok, result} = Absinthe.run(@query, @schema, variables: %{"id" => published.id})
 
@@ -123,7 +124,7 @@ defmodule EventManagerWeb.Schema.EventTest do
     end
 
     test "doesn't find a cancelled event" do
-      [_, _, cancelled, _] = events_by_statuses(@statuses)
+      %{cancelled: cancelled} = events_by_statuses(@statuses)
 
       {:ok, result} = Absinthe.run(@query, @schema, variables: %{"id" => cancelled.id})
 
@@ -131,7 +132,7 @@ defmodule EventManagerWeb.Schema.EventTest do
     end
 
     test "finds an event with closed participations" do
-      [_, _, _, participations_closed] = events_by_statuses(@statuses)
+      %{participations_closed: participations_closed} = events_by_statuses(@statuses)
 
       {:ok, result} =
         Absinthe.run(@query, @schema, variables: %{"id" => participations_closed.id})

--- a/test/event_manager_web/integrations/event_test.exs
+++ b/test/event_manager_web/integrations/event_test.exs
@@ -6,13 +6,13 @@ defmodule EventManagerWeb.Schema.EventTest do
   @schema EventManagerWeb.Schema
 
   @event_data """
-    id
-    title
-    description
-    endTime
-    startTime
-    status
-    location
+  id
+  title
+  description
+  endTime
+  startTime
+  status
+  location
   """
 
   def current_user(context \\ %{}),
@@ -44,17 +44,17 @@ defmodule EventManagerWeb.Schema.EventTest do
         Absinthe.run(@mutation, @schema, variables: %{"event" => event}, context: current_user())
 
       assert %{
-        data: %{
-          "eventCreate" => %{
-            "description" => description,
-            "endTime" => end_time,
-            "location" => location,
-            "startTime" => start_time,
-            "status" => "DRAFT",
-            "title" => title
-          }
-        }
-      } = result
+               data: %{
+                 "eventCreate" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "DRAFT",
+                   "title" => title
+                 }
+               }
+             } = result
 
       assert description == event["description"]
       assert end_time == event["endTime"]
@@ -66,14 +66,17 @@ defmodule EventManagerWeb.Schema.EventTest do
 
   describe "query event" do
     defp events_by_statuses(statuses) do
-      Enum.map(statuses, &(%Event{
+      Enum.map(
+        statuses,
+        &%Event{
           description: "Test #{&1}",
           title: "test #{&1}",
           location: "here",
           status: &1,
           start_time: DateTime.utc_now() |> DateTime.truncate(:second),
           end_time: DateTime.utc_now() |> DateTime.truncate(:second)
-        }))
+        }
+      )
       |> Enum.map(&Event.changeset/1)
       |> Enum.map(&EventManager.Repo.insert!/1)
     end
@@ -100,17 +103,17 @@ defmodule EventManagerWeb.Schema.EventTest do
       {:ok, result} = Absinthe.run(@query, @schema, variables: %{"id" => published.id})
 
       assert %{
-        data: %{
-          "event" => %{
-            "description" => description,
-            "endTime" => end_time,
-            "location" => location,
-            "startTime" => start_time,
-            "status" => "PUBLISHED",
-            "title" => title
-          }
-        }
-      } = result
+               data: %{
+                 "event" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "PUBLISHED",
+                   "title" => title
+                 }
+               }
+             } = result
 
       assert title == published.title
       assert description == published.description
@@ -134,17 +137,17 @@ defmodule EventManagerWeb.Schema.EventTest do
         Absinthe.run(@query, @schema, variables: %{"id" => participations_closed.id})
 
       assert %{
-        data: %{
-          "event" => %{
-            "description" => description,
-            "endTime" => end_time,
-            "location" => location,
-            "startTime" => start_time,
-            "status" => "PARTICIPATIONS_CLOSED",
-            "title" => title
-          }
-        }
-      } = result
+               data: %{
+                 "event" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "PARTICIPATIONS_CLOSED",
+                   "title" => title
+                 }
+               }
+             } = result
 
       assert title == participations_closed.title
       assert description == participations_closed.description
@@ -161,14 +164,14 @@ defmodule EventManagerWeb.Schema.EventTest do
       message = "event not found by id #{uuid}"
 
       assert %{
-        data: %{"event" => nil},
-        errors: [
-          %{
-            message: error,
-            path: ["event"]
-          }
-        ]
-      } = result
+               data: %{"event" => nil},
+               errors: [
+                 %{
+                   message: error,
+                   path: ["event"]
+                 }
+               ]
+             } = result
 
       assert error == message
     end
@@ -184,33 +187,34 @@ defmodule EventManagerWeb.Schema.EventTest do
     test "respond to the delete event mutation" do
       context = current_user()
 
-      event = %Event{
-        description: "Test",
-        title: "test",
-        location: "here",
-        status: :draft,
-        start_time: DateTime.utc_now() |> DateTime.truncate(:second),
-        end_time: DateTime.utc_now() |> DateTime.truncate(:second)
-      }
-      |> EventManager.Events.change_event()
-      |> Ecto.Changeset.put_assoc(:creator, context.current_user)
-      |> EventManager.Repo.insert!()
+      event =
+        %Event{
+          description: "Test",
+          title: "test",
+          location: "here",
+          status: :draft,
+          start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+          end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+        }
+        |> EventManager.Events.change_event()
+        |> Ecto.Changeset.put_assoc(:creator, context.current_user)
+        |> EventManager.Repo.insert!()
 
       {:ok, result} =
         Absinthe.run(@mutation, @schema, variables: %{"id" => event.id}, context: context)
 
       assert %{
-        data: %{
-          "eventDelete" => %{
-            "description" => description,
-            "endTime" => end_time,
-            "location" => location,
-            "startTime" => start_time,
-            "status" => "DRAFT",
-            "title" => title
-          }
-        }
-      } = result
+               data: %{
+                 "eventDelete" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "DRAFT",
+                   "title" => title
+                 }
+               }
+             } = result
 
       assert title == event.title
       assert description == event.description
@@ -222,7 +226,8 @@ defmodule EventManagerWeb.Schema.EventTest do
     test "responds invalid status when the event is not in draft status" do
       context = current_user()
 
-      event = %Event{
+      event =
+        %Event{
           description: "Test",
           title: "test",
           location: "here",
@@ -238,14 +243,14 @@ defmodule EventManagerWeb.Schema.EventTest do
         Absinthe.run(@mutation, @schema, variables: %{"id" => event.id}, context: context)
 
       assert %{
-        data: %{"eventDelete" => nil},
-        errors: [
-          %{
-            message: "only drafted events can be deleted. Current status: published",
-            path: ["eventDelete"]
-          }
-        ]
-      } = result
+               data: %{"eventDelete" => nil},
+               errors: [
+                 %{
+                   message: "only drafted events can be deleted. Current status: published",
+                   path: ["eventDelete"]
+                 }
+               ]
+             } = result
     end
 
     test "responds not found for an nonexistent event" do
@@ -257,14 +262,14 @@ defmodule EventManagerWeb.Schema.EventTest do
       message = "event not found by id #{uuid}"
 
       assert %{
-        data: %{"eventDelete" => nil},
-        errors: [
-          %{
-            message: error,
-            path: ["eventDelete"]
-          }
-        ]
-      } = result
+               data: %{"eventDelete" => nil},
+               errors: [
+                 %{
+                   message: error,
+                   path: ["eventDelete"]
+                 }
+               ]
+             } = result
 
       assert error == message
     end
@@ -272,14 +277,17 @@ defmodule EventManagerWeb.Schema.EventTest do
 
   describe "query events" do
     setup do
-      Enum.map(@statuses, &(%Event{
+      Enum.map(
+        @statuses,
+        &%Event{
           description: "Test #{&1}",
           title: "test #{&1}",
           location: "here",
           status: &1,
           start_time: DateTime.utc_now() |> DateTime.truncate(:second),
           end_time: DateTime.utc_now() |> DateTime.truncate(:second)
-        }))
+        }
+      )
       |> Enum.map(&Event.changeset/1)
       |> Enum.map(&EventManager.Repo.insert/1)
     end
@@ -302,61 +310,62 @@ defmodule EventManagerWeb.Schema.EventTest do
       {:ok, result} = Absinthe.run(@query, @schema, variables: %{"first" => 1})
 
       assert %{
-        data: %{
-          "events" => %{
-            "edges" => [
-              %{
-                "node" => %{
-                  "title" => "test published"
-                }
-              }
-            ],
-            "pageInfo" => %{
-              "hasNextPage" => false, # shouldn't this be true?
-              "hasPreviousPage" => false,
-              "endCursor" => _
-            }
-          }
-        }
-      } = result
+               data: %{
+                 "events" => %{
+                   "edges" => [
+                     %{
+                       "node" => %{
+                         "title" => "test published"
+                       }
+                     }
+                   ],
+                   "pageInfo" => %{
+                     # shouldn't this be true?
+                     "hasNextPage" => false,
+                     "hasPreviousPage" => false,
+                     "endCursor" => _
+                   }
+                 }
+               }
+             } = result
     end
 
     test "responds to the events query when using first and after" do
       {:ok, result} = Absinthe.run(@query, @schema, variables: %{"first" => 1})
 
       assert %{
-        data: %{
-          "events" => %{
-            "edges" => [
-              %{
-                "node" => %{
-                  "title" => "test published"
-                }
-              }
-            ],
-            "pageInfo" => %{
-              "endCursor" => end_cursor
-            }
-          }
-        }
-      } = result
+               data: %{
+                 "events" => %{
+                   "edges" => [
+                     %{
+                       "node" => %{
+                         "title" => "test published"
+                       }
+                     }
+                   ],
+                   "pageInfo" => %{
+                     "endCursor" => end_cursor
+                   }
+                 }
+               }
+             } = result
 
       {:ok, result} =
         Absinthe.run(@query, @schema, variables: %{"first" => 1, "after" => end_cursor})
 
       assert %{
-        data: %{
-          "events" => %{
-            "edges" => [
-              %{
-                "node" => %{
-                  "title" => "test participations_closed"
-                }
-              }
-            ]
-          }
-        }
-      } = result
+               data: %{
+                 "events" => %{
+                   "edges" => [
+                     %{
+                       "node" => %{
+                         "title" => "test participations_closed"
+                       }
+                     }
+                   ]
+                 }
+               }
+             } = result
     end
   end
 
@@ -388,17 +397,17 @@ defmodule EventManagerWeb.Schema.EventTest do
         Absinthe.run(@mutation, @schema, variables: %{"id" => event.id}, context: context)
 
       assert %{
-        data: %{
-          "eventPublish" => %{
-            "description" => description,
-            "endTime" => end_time,
-            "location" => location,
-            "startTime" => start_time,
-            "status" => "PUBLISHED",
-            "title" => title
-          }
-        }
-      } = result
+               data: %{
+                 "eventPublish" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "PUBLISHED",
+                   "title" => title
+                 }
+               }
+             } = result
 
       assert title == event.title
       assert description == event.description
@@ -410,30 +419,31 @@ defmodule EventManagerWeb.Schema.EventTest do
     test "responds invalid status when the event cannot be published" do
       context = current_user()
 
-      event = %Event{
-        description: "Test",
-        title: "test",
-        location: "here",
-        status: :ended,
-        start_time: DateTime.utc_now() |> DateTime.truncate(:second),
-        end_time: DateTime.utc_now() |> DateTime.truncate(:second)
-      }
-      |> EventManager.Events.change_event()
-      |> Ecto.Changeset.put_assoc(:creator, context.current_user)
-      |> EventManager.Repo.insert!()
+      event =
+        %Event{
+          description: "Test",
+          title: "test",
+          location: "here",
+          status: :ended,
+          start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+          end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+        }
+        |> EventManager.Events.change_event()
+        |> Ecto.Changeset.put_assoc(:creator, context.current_user)
+        |> EventManager.Repo.insert!()
 
       {:ok, result} =
         Absinthe.run(@mutation, @schema, variables: %{"id" => event.id}, context: context)
 
       assert %{
-        data: %{"eventPublish" => nil},
-        errors: [
-          %{
-            message: "only drafted events can be published. Current status: ended",
-            path: ["eventPublish"]
-          }
-        ]
-      } = result
+               data: %{"eventPublish" => nil},
+               errors: [
+                 %{
+                   message: "only drafted events can be published. Current status: ended",
+                   path: ["eventPublish"]
+                 }
+               ]
+             } = result
     end
 
     test "responds not found for an nonexistent event" do
@@ -445,14 +455,14 @@ defmodule EventManagerWeb.Schema.EventTest do
       message = "event not found by id #{uuid}"
 
       assert %{
-        data: %{"eventPublish" => nil},
-        errors: [
-          %{
-            message: error,
-            path: ["eventPublish"]
-          }
-        ]
-      } = result
+               data: %{"eventPublish" => nil},
+               errors: [
+                 %{
+                   message: error,
+                   path: ["eventPublish"]
+                 }
+               ]
+             } = result
 
       assert error == message
     end
@@ -468,33 +478,34 @@ defmodule EventManagerWeb.Schema.EventTest do
     test "respond to the cancel event mutation" do
       context = current_user()
 
-      event = %Event{
-        description: "Test",
-        title: "test",
-        location: "here",
-        status: :published,
-        start_time: DateTime.utc_now() |> DateTime.truncate(:second),
-        end_time: DateTime.utc_now() |> DateTime.truncate(:second)
-      }
-      |> EventManager.Events.change_event()
-      |> Ecto.Changeset.put_assoc(:creator, context.current_user)
-      |> EventManager.Repo.insert!()
+      event =
+        %Event{
+          description: "Test",
+          title: "test",
+          location: "here",
+          status: :published,
+          start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+          end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+        }
+        |> EventManager.Events.change_event()
+        |> Ecto.Changeset.put_assoc(:creator, context.current_user)
+        |> EventManager.Repo.insert!()
 
       {:ok, result} =
         Absinthe.run(@mutation, @schema, variables: %{"id" => event.id}, context: context)
 
       assert %{
-        data: %{
-          "eventCancel" => %{
-            "description" => description,
-            "endTime" => end_time,
-            "location" => location,
-            "startTime" => start_time,
-            "status" => "CANCELLED",
-            "title" => title
-          }
-        }
-      } = result
+               data: %{
+                 "eventCancel" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "CANCELLED",
+                   "title" => title
+                 }
+               }
+             } = result
 
       assert title == event.title
       assert description == event.description
@@ -506,30 +517,31 @@ defmodule EventManagerWeb.Schema.EventTest do
     test "responds invalid status when the event cannot be cancelled" do
       context = current_user()
 
-      event = %Event{
-        description: "Test",
-        title: "test",
-        location: "here",
-        status: :ended,
-        start_time: DateTime.utc_now() |> DateTime.truncate(:second),
-        end_time: DateTime.utc_now() |> DateTime.truncate(:second)
-      }
-      |> EventManager.Events.change_event()
-      |> Ecto.Changeset.put_assoc(:creator, context.current_user)
-      |> EventManager.Repo.insert!()
+      event =
+        %Event{
+          description: "Test",
+          title: "test",
+          location: "here",
+          status: :ended,
+          start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+          end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+        }
+        |> EventManager.Events.change_event()
+        |> Ecto.Changeset.put_assoc(:creator, context.current_user)
+        |> EventManager.Repo.insert!()
 
       {:ok, result} =
         Absinthe.run(@mutation, @schema, variables: %{"id" => event.id}, context: context)
 
       assert %{
-        data: %{"eventCancel" => nil},
-        errors: [
-          %{
-            message: "only published events can be cancelled. Current status: ended",
-            path: ["eventCancel"]
-          }
-        ]
-      } = result
+               data: %{"eventCancel" => nil},
+               errors: [
+                 %{
+                   message: "only published events can be cancelled. Current status: ended",
+                   path: ["eventCancel"]
+                 }
+               ]
+             } = result
     end
 
     test "responds not found for an nonexistent event" do
@@ -541,14 +553,14 @@ defmodule EventManagerWeb.Schema.EventTest do
       message = "event not found by id #{uuid}"
 
       assert %{
-        data: %{"eventCancel" => nil},
-        errors: [
-          %{
-            message: error,
-            path: ["eventCancel"]
-          }
-        ]
-      } = result
+               data: %{"eventCancel" => nil},
+               errors: [
+                 %{
+                   message: error,
+                   path: ["eventCancel"]
+                 }
+               ]
+             } = result
 
       assert error == message
     end

--- a/test/event_manager_web/integrations/event_test.exs
+++ b/test/event_manager_web/integrations/event_test.exs
@@ -239,7 +239,23 @@ defmodule EventManagerWeb.Schema.EventTest do
           description: "Test2",
           title: "test2",
           location: "here",
-          status: :draft,
+          status: :published,
+          start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+          end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+        },
+        %Event{
+          description: "Test3",
+          title: "test3",
+          location: "here",
+          status: :cancelled,
+          start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+          end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+        },
+        %Event{
+          description: "Test4",
+          title: "test4",
+          location: "here",
+          status: :participations_closed,
           start_time: DateTime.utc_now() |> DateTime.truncate(:second),
           end_time: DateTime.utc_now() |> DateTime.truncate(:second)
         }
@@ -271,12 +287,12 @@ defmodule EventManagerWeb.Schema.EventTest do
                    "edges" => [
                      %{
                        "node" => %{
-                         "title" => "test1"
+                         "title" => "test2"
                        }
                      }
                    ],
                    "pageInfo" => %{
-                     "hasNextPage" => false,
+                     "hasNextPage" => false, # should be true
                      "hasPreviousPage" => false,
                      # credo:disable-for-next-line Credo.Check.Readability.VariableNames
                      "endCursor" => endCursor
@@ -289,12 +305,39 @@ defmodule EventManagerWeb.Schema.EventTest do
     test "responds to the events query when using first and after" do
       {:ok, result} = Absinthe.run(@query, @schema, variables: %{"first" => 1})
       # credo:disable-for-next-line Credo.Check.Readability.VariableNames
-      %{data: %{"events" => %{"pageInfo" => %{"endCursor" => endCursor}}}} = result
+      assert %{
+               data: %{
+                 "events" => %{
+                   "edges" => [
+                     %{
+                       "node" => %{
+                          "title" => "test2"
+                        }
+                      }
+                    ],
+                   "pageInfo" => %{
+                     "endCursor" => endCursor
+                   }
+                 }
+               }
+             } = result
 
       {:ok, result} =
         Absinthe.run(@query, @schema, variables: %{"first" => 1, "after" => endCursor})
 
-      %{data: %{"events" => %{"edges" => [%{"node" => %{"title" => "test2"}}]}}} = result
+      assert %{
+               data: %{
+                 "events" => %{
+                   "edges" => [
+                     %{
+                       "node" => %{
+                          "title" => "test4"
+                        }
+                      }
+                    ]
+                  }
+                }
+              } = result
     end
   end
 


### PR DESCRIPTION
Now when querying for events we should only get those with status `published` or `participations_closed`.

The lint check failed, so I refactored the event tests and made it pass.