### PR TITLE
feature / attendances crud

### DIFF
--- a/dev/support/seeds.ex
+++ b/dev/support/seeds.ex
@@ -126,7 +126,8 @@ defmodule EventManager.Seeds do
     # CREATE ATTENDANCES
     #
 
-    Enum.each([dwight, jim, pam],
+    Enum.each(
+      [dwight, jim, pam],
       fn u ->
         %Attendances.Attendance{
           attendee: u,

--- a/dev/support/seeds.ex
+++ b/dev/support/seeds.ex
@@ -1,0 +1,78 @@
+defmodule EventManager.Seeds do
+  alias EventManager.{Users, Events, Attendances, Repo}
+  import Ecto.Query, only: [from: 2]
+
+  #
+  # HELPERS
+  #
+
+  def create_user(tag) do
+    %Users.User{
+      id: Ecto.UUID.generate(),
+      email: "email#{tag}",
+      name: "name#{tag}",
+      username: "username#{tag}",
+      first_name: "first_name#{tag}",
+      last_name: "last_name#{tag}"
+    }
+    |> Repo.insert!()
+  end
+
+  def create_event(tag, creator) do
+    %Events.Event{
+      creator: creator,
+      title: "title#{tag}",
+      description: "description#{tag}",
+      location: "location#{tag}",
+      status: :published,
+      start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+      end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+    }
+    |> Repo.insert!()
+  end
+
+  def first_by(queryable, field) do
+    where = [{field, "#{field}1"}]
+    Repo.one(from queryable, where: ^where)
+  end
+
+  def run do
+    #
+    # CLEAN DATABASE
+    #
+
+    Repo.delete_all(Attendances.Attendance)
+    Repo.delete_all(Events.Event)
+    Repo.delete_all(Users.User)
+
+    #
+    # CREATE USERS
+    #
+
+    Enum.each(1..5, &create_user(&1))
+
+    #
+    # CREATE EVENTS
+    #
+
+    creator = first_by(Users.User, :name)
+    Enum.each(1..5, &create_event(&1, creator))
+
+    #
+    # CREATE ATTENDANCES
+    #
+
+    [_creator | others] = Repo.all(Users.User)
+    event1 = first_by(Events.Event, :title)
+    Enum.each(
+      others,
+      fn other ->
+        %Attendances.Attendance{
+          attendee: other,
+          event: event1
+        }
+        |> Repo.insert!()
+      end
+    )
+  end
+end

--- a/dev/support/seeds.ex
+++ b/dev/support/seeds.ex
@@ -1,42 +1,7 @@
 defmodule EventManager.Seeds do
-  alias EventManager.{Users, Events, Attendances, Repo}
-  import Ecto.Query, only: [from: 2]
-
-  #
-  # HELPERS
-  #
-
-  def create_user(tag) do
-    %Users.User{
-      id: Ecto.UUID.generate(),
-      email: "email#{tag}",
-      name: "name#{tag}",
-      username: "username#{tag}",
-      first_name: "first_name#{tag}",
-      last_name: "last_name#{tag}"
-    }
-    |> Repo.insert!()
-  end
-
-  def create_event(tag, creator) do
-    %Events.Event{
-      creator: creator,
-      title: "title#{tag}",
-      description: "description#{tag}",
-      location: "location#{tag}",
-      status: :published,
-      start_time: DateTime.utc_now() |> DateTime.truncate(:second),
-      end_time: DateTime.utc_now() |> DateTime.truncate(:second)
-    }
-    |> Repo.insert!()
-  end
-
-  def first_by(queryable, field) do
-    where = [{field, "#{field}1"}]
-    Repo.one(from queryable, where: ^where)
-  end
-
   def run do
+    alias EventManager.{Attendances, Events, Users, Repo}
+
     #
     # CLEAN DATABASE
     #
@@ -49,30 +14,131 @@ defmodule EventManager.Seeds do
     # CREATE USERS
     #
 
-    Enum.each(1..5, &create_user(&1))
+    michael =
+      %Users.User{
+        id: craft_id(),
+        email: "michael@scott.com",
+        first_name: "Michael",
+        last_name: "Scott",
+        name: "Michael Scott",
+        username: "mscott"
+      }
+      |> Repo.insert!()
+
+    dwight =
+      %Users.User{
+        id: craft_id(),
+        email: "dwight@schrute.com",
+        first_name: "Dwight",
+        last_name: "Schrute",
+        name: "Dwight Schrute",
+        username: "dschrute"
+      }
+      |> Repo.insert!()
+
+    jim =
+      %Users.User{
+        id: craft_id(),
+        email: "jim@halpert.com",
+        first_name: "Jim",
+        last_name: "Halpert",
+        name: "Jim Halpert",
+        username: "jhalpert"
+      }
+      |> Repo.insert!()
+
+    pam =
+      %Users.User{
+        id: craft_id(),
+        email: "pam@beesly.com",
+        first_name: "Pam",
+        last_name: "Beesly",
+        name: "Pam Beesly",
+        username: "pbeesly"
+      }
+      |> Repo.insert!()
 
     #
     # CREATE EVENTS
     #
 
-    creator = first_by(Users.User, :name)
-    Enum.each(1..5, &create_event(&1, creator))
+    diversity_day =
+      %Events.Event{
+        creator: michael,
+        title: "Diversity Day",
+        description: "A consultant will join us talk about tolerance and diversity",
+        location: "The office",
+        status: :published,
+        start_time: time_now(),
+        end_time: time_now()
+      }
+      |> Repo.insert!()
+
+    _basketball_game =
+      %Events.Event{
+        creator: michael,
+        title: "Basketball Game",
+        description: "Us vs the warehouse workers",
+        location: "The warehouse",
+        status: :published,
+        start_time: time_now(),
+        end_time: time_now()
+      }
+      |> Repo.insert!()
+
+    _office_olympics =
+      %Events.Event{
+        creator: michael,
+        title: "Office Olympics",
+        description: "Came up with a bunch of office games, let's play",
+        location: "The office",
+        status: :published,
+        start_time: time_now(),
+        end_time: time_now()
+      }
+      |> Repo.insert!()
+
+    _take_your_daughter_to_work_day =
+      %Events.Event{
+        creator: michael,
+        title: "Take Your Daughter To Work Day",
+        description: "Let's show off how hard we work to our loved ones",
+        location: "Dunder Mifflin",
+        status: :published,
+        start_time: time_now(),
+        end_time: time_now()
+      }
+      |> Repo.insert!()
+
+    _dinner_party =
+      %Events.Event{
+        creator: michael,
+        title: "Dinner Party",
+        description: "Couples-only dinner party",
+        location: "Michael's home",
+        status: :published,
+        start_time: time_now(),
+        end_time: time_now()
+      }
+      |> Repo.insert!()
 
     #
     # CREATE ATTENDANCES
     #
 
-    [_creator | others] = Repo.all(Users.User)
-    event1 = first_by(Events.Event, :title)
-    Enum.each(
-      others,
-      fn other ->
+    Enum.each([dwight, jim, pam],
+      fn u ->
         %Attendances.Attendance{
-          attendee: other,
-          event: event1
+          attendee: u,
+          event: diversity_day
         }
         |> Repo.insert!()
       end
     )
+
+    :ok
   end
+
+  defp time_now, do: DateTime.utc_now() |> DateTime.truncate(:second)
+  defp craft_id, do: Ecto.UUID.generate()
 end

--- a/lib/event_manager/attendances.ex
+++ b/lib/event_manager/attendances.ex
@@ -1,0 +1,107 @@
+defmodule EventManager.Attendances do
+  @moduledoc """
+  The Attendances context.
+  """
+
+  import Ecto.Query, warn: false
+  alias EventManager.Repo
+
+  alias EventManager.Attendances.Attendance
+
+  @doc """
+  Returns the list of attendances.
+
+  ## Examples
+
+      iex> list_attendances()
+      [%Attendance{}, ...]
+  """
+  def list_attendances, do: Repo.all(Attendance)
+
+  @doc """
+  Gets a single attendance.
+
+  Raises `Ecto.NoResultsError` if the Attendance does not exist.
+
+  ## Examples
+
+      iex> get_attendance!(123)
+      %Attendance{}
+
+      iex> get_attendance!(456)
+      ** (Ecto.NoResultsError)
+  """
+  def get_attendance!(id), do: Repo.get!(Attendance, id)
+
+  @doc """
+  Creates a attendance.
+
+  ## Examples
+
+      iex> create_attendance(%{field: value})
+      {:ok, %Attendance{}}
+
+      iex> create_attendance(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def create_attendance(attrs \\ %{})
+
+  def create_attendance(%{event_id: event_id} = attrs) when not is_nil(event_id) do
+    event = EventManager.Events.get_event(event_id) # load event's creator and attendees?
+
+    %Attendance{}
+    |> Attendance.changeset(attrs)
+    |> Ecto.Changeset.put_assoc(:event, event)
+    |> Repo.insert()
+  end
+
+  def create_attendance(attrs) do
+    %Attendance{}
+    |> Attendance.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a attendance.
+
+  ## Examples
+
+      iex> update_attendance(attendance, %{field: new_value})
+      {:ok, %Attendance{}}
+
+      iex> update_attendance(attendance, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+  """
+  def update_attendance(%Attendance{} = attendance, attrs) do
+    attendance
+    |> Attendance.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Attendance.
+
+  ## Examples
+
+      iex> delete_attendance(attendance)
+      {:ok, %Attendance{}}
+
+      iex> delete_attendance(attendance)
+      {:error, %Ecto.Changeset{}}
+  """
+  def delete_attendance(%Attendance{} = attendance) do
+    Repo.delete(attendance)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking attendance changes.
+
+  ## Examples
+
+      iex> change_attendance(attendance)
+      %Ecto.Changeset{source: %Attendance{}}
+  """
+  def change_attendance(%Attendance{} = attendance) do
+    Attendance.changeset(attendance, %{})
+  end
+end

--- a/lib/event_manager/attendances.ex
+++ b/lib/event_manager/attendances.ex
@@ -44,19 +44,7 @@ defmodule EventManager.Attendances do
       iex> create_attendance(%{field: bad_value})
       {:error, %Ecto.Changeset{}}
   """
-  def create_attendance(attrs \\ %{})
-
-  def create_attendance(%{event_id: event_id} = attrs) when not is_nil(event_id) do
-    # load event's creator and attendees?
-    event = EventManager.Events.get_event(event_id)
-
-    %Attendance{}
-    |> Attendance.changeset(attrs)
-    |> Ecto.Changeset.put_assoc(:event, event)
-    |> Repo.insert()
-  end
-
-  def create_attendance(attrs) do
+  def create_attendance(attrs \\ %{}) do
     %Attendance{}
     |> Attendance.changeset(attrs)
     |> Repo.insert()

--- a/lib/event_manager/attendances.ex
+++ b/lib/event_manager/attendances.ex
@@ -47,7 +47,8 @@ defmodule EventManager.Attendances do
   def create_attendance(attrs \\ %{})
 
   def create_attendance(%{event_id: event_id} = attrs) when not is_nil(event_id) do
-    event = EventManager.Events.get_event(event_id) # load event's creator and attendees?
+    # load event's creator and attendees?
+    event = EventManager.Events.get_event(event_id)
 
     %Attendance{}
     |> Attendance.changeset(attrs)

--- a/lib/event_manager/attendances/attendance.ex
+++ b/lib/event_manager/attendances/attendance.ex
@@ -1,0 +1,26 @@
+defmodule EventManager.Attendances.Attendance do
+  @moduledoc """
+  Represents an event attendance by a user account (attendee)
+  or simply by an email address.
+  """
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key {:id, :binary_id, autogenerate: true}
+  @foreign_key_type :binary_id
+
+  schema "attendances" do
+    field :email, :string
+    belongs_to :attendee, EventManager.Users.User, foreign_key: :attendee_id
+    belongs_to :event, EventManager.Events.Event
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(attendance, attrs) do
+    attendance
+    |> cast(attrs, [:email, :event_id])
+    |> validate_required([:event_id])
+  end
+end

--- a/lib/event_manager/attendances/attendance.ex
+++ b/lib/event_manager/attendances/attendance.ex
@@ -18,9 +18,27 @@ defmodule EventManager.Attendances.Attendance do
   end
 
   @doc false
-  def changeset(attendance, attrs) do
-    attendance
-    |> cast(attrs, [:email, :event_id, :attendee_id])
-    |> validate_required([:event_id])
+  def changeset(struct, %{attendee_id: _} = attrs), do: user_changeset(struct, attrs)
+  def changeset(struct, %{email: _} = attrs), do: email_changeset(struct, attrs)
+
+  def changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:event_id])
+    |> add_error(:event_id, "provide email OR user along the event")
+  end
+
+  defp user_changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:event_id, :attendee_id])
+    |> validate_required([:event_id, :attendee_id])
+    |> foreign_key_constraint(:attendee_id)
+    |> foreign_key_constraint(:event_id)
+  end
+
+  defp email_changeset(struct, attrs) do
+    struct
+    |> cast(attrs, [:event_id, :email])
+    |> validate_required([:event_id, :email])
+    |> foreign_key_constraint(:event_id)
   end
 end

--- a/lib/event_manager/attendances/attendance.ex
+++ b/lib/event_manager/attendances/attendance.ex
@@ -20,7 +20,7 @@ defmodule EventManager.Attendances.Attendance do
   @doc false
   def changeset(attendance, attrs) do
     attendance
-    |> cast(attrs, [:email, :event_id])
+    |> cast(attrs, [:email, :event_id, :attendee_id])
     |> validate_required([:event_id])
   end
 end

--- a/lib/event_manager/events/event.ex
+++ b/lib/event_manager/events/event.ex
@@ -7,7 +7,9 @@ defmodule EventManager.Events.Event do
   import Ecto.Changeset
   import EctoEnum
 
-  defenum(StatusEnum, ["draft", "published", "ended", "cancelled", "participations_closed"])
+  alias EventManager.{Users, Attendances}
+
+  defenum(StatusEnum, ~w(draft published ended cancelled participations_closed))
 
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
@@ -20,7 +22,11 @@ defmodule EventManager.Events.Event do
     field :status, StatusEnum, default: "draft"
     field :start_time, :utc_datetime
     field :end_time, :utc_datetime
-    belongs_to :creator, EventManager.Users.User, foreign_key: :creator_id
+    belongs_to :creator, Users.User, foreign_key: :creator_id
+
+    many_to_many :attendees, Users.User,
+      join_through: Attendances.Attendance,
+      join_keys: [event_id: :id, attendee_id: :id]
 
     timestamps()
   end
@@ -33,5 +39,6 @@ defmodule EventManager.Events.Event do
     struct
     |> cast(params, [:title, :description, :location, :public, :status, :start_time, :end_time])
     |> validate_required([:title, :description, :location, :status, :start_time, :end_time])
+    |> foreign_key_constraint(:creator)
   end
 end

--- a/lib/event_manager/events/event.ex
+++ b/lib/event_manager/events/event.ex
@@ -7,7 +7,7 @@ defmodule EventManager.Events.Event do
   import Ecto.Changeset
   import EctoEnum
 
-  alias EventManager.{Users, Attendances}
+  alias EventManager.{Attendances, Users}
 
   defenum(StatusEnum, ~w(draft published ended cancelled participations_closed))
 

--- a/lib/event_manager/events/event.ex
+++ b/lib/event_manager/events/event.ex
@@ -1,13 +1,14 @@
 defmodule EventManager.Events.Event do
   @moduledoc """
-    An event organized by a community
+  An event organized by a community.
   """
 
   use Ecto.Schema
   import Ecto.Changeset
   import EctoEnum
 
-  alias EventManager.{Attendances, Users}
+  alias EventManager.Attendances.Attendance
+  alias EventManager.Users.User
 
   defenum(StatusEnum, ~w(draft published ended cancelled participations_closed))
 
@@ -22,10 +23,10 @@ defmodule EventManager.Events.Event do
     field :status, StatusEnum, default: "draft"
     field :start_time, :utc_datetime
     field :end_time, :utc_datetime
-    belongs_to :creator, Users.User, foreign_key: :creator_id
+    belongs_to :creator, User, foreign_key: :creator_id
 
-    many_to_many :attendees, Users.User,
-      join_through: Attendances.Attendance,
+    many_to_many :attendees, User,
+      join_through: Attendance,
       join_keys: [event_id: :id, attendee_id: :id]
 
     timestamps()

--- a/lib/event_manager/users/user.ex
+++ b/lib/event_manager/users/user.ex
@@ -5,6 +5,8 @@ defmodule EventManager.Users.User do
   use Ecto.Schema
   import Ecto.Changeset
 
+  alias EventManager.{Events, Attendances}
+
   @default_locale Application.get_env(:gettext, :default_locale)
   @primary_key {:id, :binary_id, autogenerate: false}
   @foreign_key_type :binary_id
@@ -16,7 +18,11 @@ defmodule EventManager.Users.User do
     field :first_name, :string
     field :last_name, :string
     field :locale, :string, default: @default_locale
-    has_many :created_events, EventManager.Events.Event, foreign_key: :creator_id
+    has_many :created_events, Events.Event, foreign_key: :creator_id
+
+    many_to_many :events_to_attend, Events.Event,
+      join_through: Attendances.Attendance,
+      join_keys: [attendee_id: :id, event_id: :id]
 
     timestamps()
   end

--- a/lib/event_manager/users/user.ex
+++ b/lib/event_manager/users/user.ex
@@ -1,11 +1,12 @@
 defmodule EventManager.Users.User do
   @moduledoc """
-    A user from the OpenID Connect provider
+  A user from the OpenID Connect provider.
   """
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias EventManager.{Attendances, Events}
+  alias EventManager.Attendances.Attendance
+  alias EventManager.Events.Event
 
   @default_locale Application.get_env(:gettext, :default_locale)
   @primary_key {:id, :binary_id, autogenerate: false}
@@ -18,10 +19,10 @@ defmodule EventManager.Users.User do
     field :first_name, :string
     field :last_name, :string
     field :locale, :string, default: @default_locale
-    has_many :created_events, Events.Event, foreign_key: :creator_id
+    has_many :created_events, Event, foreign_key: :creator_id
 
-    many_to_many :events_to_attend, Events.Event,
-      join_through: Attendances.Attendance,
+    many_to_many :events_to_attend, Event,
+      join_through: Attendance,
       join_keys: [attendee_id: :id, event_id: :id]
 
     timestamps()

--- a/lib/event_manager/users/user.ex
+++ b/lib/event_manager/users/user.ex
@@ -5,7 +5,7 @@ defmodule EventManager.Users.User do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias EventManager.{Events, Attendances}
+  alias EventManager.{Attendances, Events}
 
   @default_locale Application.get_env(:gettext, :default_locale)
   @primary_key {:id, :binary_id, autogenerate: false}

--- a/mix.exs
+++ b/mix.exs
@@ -25,8 +25,9 @@ defmodule EventManager.MixProject do
   end
 
   # Specifies which paths to compile per environment.
-  defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(:test), do: ["lib", "dev/support", "test/support"]
+  defp elixirc_paths(:dev),  do: ["lib", "dev/support"]
+  defp elixirc_paths(_),     do: ["lib"]
 
   # Specifies your project dependencies.
   #

--- a/mix.exs
+++ b/mix.exs
@@ -26,8 +26,8 @@ defmodule EventManager.MixProject do
 
   # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "dev/support", "test/support"]
-  defp elixirc_paths(:dev),  do: ["lib", "dev/support"]
-  defp elixirc_paths(_),     do: ["lib"]
+  defp elixirc_paths(:dev), do: ["lib", "dev/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   # Specifies your project dependencies.
   #

--- a/priv/repo/migrations/20191025133034_create_attendances.exs
+++ b/priv/repo/migrations/20191025133034_create_attendances.exs
@@ -1,0 +1,17 @@
+defmodule EventManager.Repo.Migrations.CreateAttendances do
+  use Ecto.Migration
+
+  def change do
+    create table(:attendances, primary_key: false) do
+      add :id, :binary_id, primary_key: true
+      add :email, :string
+      add :attendee_id, references(:users, on_delete: :nothing, type: :binary_id)
+      add :event_id, references(:events, on_delete: :nothing, type: :binary_id)
+
+      timestamps()
+    end
+
+    create unique_index(:attendances, [:attendee_id, :event_id])
+    create unique_index(:attendances, [:email, :event_id])
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -2,10 +2,5 @@
 #
 #     mix run priv/repo/seeds.exs
 #
-# Inside the script, you can read and write to any of your
-# repositories directly:
-#
-#     EventManager.Repo.insert!(%EventManager.SomeSchema{})
-#
-# We recommend using the bang functions (`insert!`, `update!`
-# and so on) as they will fail if something goes wrong.
+
+EventManager.Seeds.run()

--- a/test/event_manager/attendances_test.exs
+++ b/test/event_manager/attendances_test.exs
@@ -74,8 +74,7 @@ defmodule EventManager.AttendancesTest do
     } do
       attendance = attendance_fixture(valid_email)
 
-      assert {:ok, attendance} =
-               Attendances.update_attendance(attendance, update_email)
+      assert {:ok, attendance} = Attendances.update_attendance(attendance, update_email)
 
       assert attendance.email == "@new"
     end

--- a/test/event_manager/attendances_test.exs
+++ b/test/event_manager/attendances_test.exs
@@ -1,0 +1,73 @@
+defmodule EventManager.AttendancesTest do
+  use EventManager.DataCase
+
+  alias EventManager.{Attendances, Events}
+
+  describe "attendances" do
+    alias EventManager.Attendances.Attendance
+
+    setup do
+      EventManager.Seeds.run()
+
+      event_id =
+        Events.Event
+        |> EventManager.Seeds.first_by(:title)
+        |> Map.fetch!(:id)
+
+      {
+        :ok,
+        valid_attrs: %{email: "@example.com", event_id: event_id},
+        update_attrs: %{email: "@example.io", event_id: event_id},
+        invalid_attrs: %{event_id: nil}
+      }
+    end
+
+    def attendance_fixture(attrs \\ %{}) do
+      {:ok, attendance} =
+        Attendances.create_attendance(attrs)
+
+      attendance
+    end
+
+    test "create attendance with valid data", %{valid_attrs: valid_attrs} do
+      assert {:ok, %Attendance{} = attendance} = Attendances.create_attendance(valid_attrs)
+      assert attendance.email == "@example.com"
+    end
+
+    test "new attendance loads an event", %{valid_attrs: valid_attrs} do
+      assert {:ok, %Attendance{} = attendance} = Attendances.create_attendance(valid_attrs)
+      assert attendance.event.title == "title1"
+    end
+
+    test "create attendance with invalid data returns error", %{invalid_attrs: invalid_attrs} do
+      assert {:error, %Ecto.Changeset{}} = Attendances.create_attendance(invalid_attrs)
+    end
+
+    test "update attendance with valid data", %{valid_attrs: valid_attrs, update_attrs: update_attrs} do
+      attendance = attendance_fixture(valid_attrs)
+
+      assert {:ok, %Attendance{} = attendance} =
+               Attendances.update_attendance(attendance, update_attrs)
+
+      assert attendance.email == "@example.io"
+    end
+
+    test "update attendance with invalid data returns error", %{valid_attrs: valid_attrs, invalid_attrs: invalid_attrs} do
+      attendance = attendance_fixture(valid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Attendances.update_attendance(attendance, invalid_attrs)
+    end
+
+    test "delete_attendance/1", %{valid_attrs: valid_attrs} do
+      attendance = attendance_fixture(valid_attrs)
+      assert {:ok, %Attendance{}} = Attendances.delete_attendance(attendance)
+      assert_raise Ecto.NoResultsError, fn -> Attendances.get_attendance!(attendance.id) end
+    end
+
+    test "change_attendance/1 returns an attendance changeset", %{valid_attrs: valid_attrs} do
+      attendance = attendance_fixture(valid_attrs)
+      assert %Ecto.Changeset{} = Attendances.change_attendance(attendance)
+    end
+  end
+end

--- a/test/event_manager/attendances_test.exs
+++ b/test/event_manager/attendances_test.exs
@@ -23,8 +23,7 @@ defmodule EventManager.AttendancesTest do
     end
 
     def attendance_fixture(attrs \\ %{}) do
-      {:ok, attendance} =
-        Attendances.create_attendance(attrs)
+      {:ok, attendance} = Attendances.create_attendance(attrs)
 
       attendance
     end
@@ -43,7 +42,10 @@ defmodule EventManager.AttendancesTest do
       assert {:error, %Ecto.Changeset{}} = Attendances.create_attendance(invalid_attrs)
     end
 
-    test "update attendance with valid data", %{valid_attrs: valid_attrs, update_attrs: update_attrs} do
+    test "update attendance with valid data", %{
+      valid_attrs: valid_attrs,
+      update_attrs: update_attrs
+    } do
       attendance = attendance_fixture(valid_attrs)
 
       assert {:ok, %Attendance{} = attendance} =
@@ -52,7 +54,10 @@ defmodule EventManager.AttendancesTest do
       assert attendance.email == "@example.io"
     end
 
-    test "update attendance with invalid data returns error", %{valid_attrs: valid_attrs, invalid_attrs: invalid_attrs} do
+    test "update attendance with invalid data returns error", %{
+      valid_attrs: valid_attrs,
+      invalid_attrs: invalid_attrs
+    } do
       attendance = attendance_fixture(valid_attrs)
 
       assert {:error, %Ecto.Changeset{}} =

--- a/test/event_manager/events_test.exs
+++ b/test/event_manager/events_test.exs
@@ -8,41 +8,27 @@ defmodule EventManager.EventsTest do
 
     @valid_attrs %{
       description: "Test",
-      title: "test",
-      location: "here",
-      public: true,
+      title: "Test",
+      location: "Here",
       status: :draft,
-      start_time:
-        DateTime.utc_now()
-        |> DateTime.truncate(:second)
-        |> DateTime.to_iso8601(),
-      end_time:
-        DateTime.utc_now()
-        |> DateTime.truncate(:second)
-        |> DateTime.to_iso8601()
+      start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+      end_time: DateTime.utc_now() |> DateTime.truncate(:second)
     }
 
-    @update_attrs %{
-      description: "Different description"
-    }
+    @update_attrs %{description: "New description"}
 
     @invalid_attrs %{
       description: "Test",
-      title: "test",
-      location: "here",
-      public: "test",
+      title: "Test",
+      location: "Here",
+      public: "true",
       start_time: "false",
       end_time: 1
     }
 
-    def event_fixture(attrs \\ %{}) do
-      {:ok, event} =
-        attrs
-        |> Enum.into(@valid_attrs)
-        |> Events.create_event()
-
-      event
-    end
+    #
+    # READ
+    #
 
     test "list_events/0 returns all events" do
       event = event_fixture()
@@ -59,17 +45,27 @@ defmodule EventManager.EventsTest do
       assert Events.get_event(event.id) == event
     end
 
+    #
+    # CREATE
+    #
+
     test "create_event/1 with valid data creates a event" do
-      assert {:ok, %Event{} = event} = Events.create_event(@valid_attrs)
+      assert {:ok, event} = Events.create_event(@valid_attrs)
+      assert event.description == "Test"
     end
 
     test "create_event/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} = Events.create_event(@invalid_attrs)
     end
 
+    #
+    # UPDATE
+    #
+
     test "update_event/2 with valid data updates the event" do
-      event = event_fixture()
-      assert {:ok, %Event{} = event} = Events.update_event(event, @update_attrs)
+      event = event_fixture(%{description: "Old description"})
+      assert {:ok, event} = Events.update_event(event, @update_attrs)
+      assert event.description == "New description"
     end
 
     test "update_event/2 with invalid data returns error changeset" do
@@ -78,11 +74,19 @@ defmodule EventManager.EventsTest do
       assert event == Events.get_event!(event.id)
     end
 
+    #
+    # DELETE
+    #
+
     test "delete_event/1 deletes the event" do
       event = event_fixture()
       assert {:ok, %Event{}} = Events.delete_event(event)
       assert_raise Ecto.NoResultsError, fn -> Events.get_event!(event.id) end
     end
+
+    #
+    # CHANGESET
+    #
 
     test "change_event/1 returns a event changeset" do
       event = event_fixture()

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -37,23 +37,38 @@ defmodule EventManager.DataCase do
     :ok
   end
 
-  alias EventManager.Users
+  alias EventManager.{Events, Users}
 
   def user_fixture(attrs \\ %{}) do
     {:ok, user} =
       attrs
       |> Enum.into(%{
-        id: Ecto.UUID.generate(),
+        name: attrs[:name] || "Fake User",
         email: "user@example.com",
-        name: "Fake User",
-        username: "user",
         first_name: "Fake",
         last_name: "User",
-        locale: "en"
+        locale: "en",
+        username: "user",
+        id: Ecto.UUID.generate()
       })
       |> Users.create_user()
 
     user
+  end
+
+  def event_fixture(attrs \\ %{}) do
+    {:ok, event} =
+      attrs
+      |> Enum.into(%{
+        title: attrs[:title] || "Fake Event",
+        description: "A fake event",
+        location: "Here",
+        start_time: DateTime.utc_now() |> DateTime.truncate(:second),
+        end_time: DateTime.utc_now() |> DateTime.truncate(:second)
+      })
+      |> Events.create_event()
+
+    event
   end
 
   @doc """

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -60,9 +60,11 @@ defmodule EventManager.DataCase do
     {:ok, event} =
       attrs
       |> Enum.into(%{
+        description: attrs[:description] || "A fake event",
         title: attrs[:title] || "Fake Event",
-        description: "A fake event",
+        public: attrs[:public] || true,
         location: "Here",
+        status: attrs[:status] || :draft,
         start_time: DateTime.utc_now() |> DateTime.truncate(:second),
         end_time: DateTime.utc_now() |> DateTime.truncate(:second)
       })


### PR DESCRIPTION
Create attendances migration, schema, context and tests.
Create seeds module that can be useful for tests, I used it in the `attendances_tests`.
Simply run `mix ecto.reset` to drop, create, migrate and seed.