### PR TITLE
feature / event attend

### DIFF
--- a/lib/event_manager_web/resolvers/attendances.ex
+++ b/lib/event_manager_web/resolvers/attendances.ex
@@ -9,15 +9,16 @@ defmodule EventManagerWeb.Resolvers.Attendances do
 
   # import EventManagerWeb.Gettext
 
-  def create_attendance(args, %{context: %{current_user: current_user}}) do
-    case Map.put(args, :attendee, current_user)
+  def create_attendance(args, %{context: %{current_user: user}}) do
+    case Map.put(args, :attendee_id, user.id)
          |> Attendances.create_attendance() do
       {:ok, attendance} ->
-        # attendance = Repo.preload(attendance, [:attendee, :event])
+        # (attendance, [:attendee, :event])
+        attendance = EventManager.Repo.preload(attendance, :event)
         {:ok, attendance.event}
 
       {:error, changeset} ->
-       {:error, changeset.errors}
+        {:error, changeset.errors}
     end
   end
 

--- a/lib/event_manager_web/resolvers/attendances.ex
+++ b/lib/event_manager_web/resolvers/attendances.ex
@@ -13,7 +13,6 @@ defmodule EventManagerWeb.Resolvers.Attendances do
     case Map.put(args, :attendee_id, user.id)
          |> Attendances.create_attendance() do
       {:ok, attendance} ->
-        # (attendance, [:attendee, :event])
         attendance = EventManager.Repo.preload(attendance, :event)
         {:ok, attendance.event}
 

--- a/lib/event_manager_web/resolvers/attendances.ex
+++ b/lib/event_manager_web/resolvers/attendances.ex
@@ -1,0 +1,34 @@
+defmodule EventManagerWeb.Resolvers.Attendances do
+  @moduledoc """
+  Resolvers for Attendance objects and related queries.
+  """
+
+  # alias Absinthe.Relay.Connection
+  alias EventManager.Attendances
+  # alias Phoenix.PubSub
+
+  # import EventManagerWeb.Gettext
+
+  def create_attendance(args, %{context: %{current_user: current_user}}) do
+    case Map.put(args, :attendee, current_user)
+         |> Attendances.create_attendance() do
+      {:ok, attendance} ->
+        # attendance = Repo.preload(attendance, [:attendee, :event])
+        {:ok, attendance.event}
+
+      {:error, changeset} ->
+       {:error, changeset.errors}
+    end
+  end
+
+  def create_attendance(args, _info) do
+    case Attendances.create_attendance(args) do
+      {:ok, attendance} ->
+        attendance = EventManager.Repo.preload(attendance, :event)
+        {:ok, attendance.event}
+
+      {:error, changeset} ->
+        {:error, changeset.errors}
+    end
+  end
+end

--- a/lib/event_manager_web/schema/events.ex
+++ b/lib/event_manager_web/schema/events.ex
@@ -7,6 +7,7 @@ defmodule EventManagerWeb.Schema.Events do
   use Absinthe.Schema.Notation
   use Absinthe.Relay.Schema, :modern
 
+  alias EventManagerWeb.Resolvers.Attendances
   alias EventManagerWeb.Resolvers.Events
   Absinthe.Relay.Connection.Notation
   import_types(EventManagerWeb.Types.Event)
@@ -50,6 +51,14 @@ defmodule EventManagerWeb.Schema.Events do
       arg(:id, non_null(:id))
 
       resolve(&Events.cancel_event/2)
+    end
+
+    @desc "Attend an event"
+    field :event_attend, :event do
+      arg(:event_id, non_null(:id))
+      arg(:email, :string)
+
+      resolve(&Attendances.create_attendance/2)
     end
   end
 end

--- a/test/event_manager_web/integrations/event_test.exs
+++ b/test/event_manager_web/integrations/event_test.exs
@@ -566,4 +566,38 @@ defmodule EventManagerWeb.Schema.EventTest do
       assert error == message
     end
   end
+
+  describe "mutation eventAttend" do
+    @mutation """
+    mutation($eventId: ID!, $email: String) {
+      eventAttend(eventId: $eventId, email: $email) { #{@event_data} }
+    }
+    """
+
+    test "accepts an email" do
+      event = event_fixture(status: :published)
+      variables = %{"eventId" => event.id, "email" => "@"}
+
+      {:ok, result} = Absinthe.run(@mutation, @schema, variables: variables)
+
+      assert %{
+          data: %{
+            "eventAttend" => %{
+              "description" => description,
+              "endTime" => end_time,
+              "location" => location,
+              "startTime" => start_time,
+              "status" => "PUBLISHED",
+              "title" => title
+            }
+          }
+        } = result
+
+      assert description == event.description
+      assert end_time == event.end_time |> DateTime.to_iso8601()
+      assert location == event.location
+      assert start_time == event.start_time |> DateTime.to_iso8601()
+      assert title == event.title
+    end
+  end
 end

--- a/test/event_manager_web/integrations/event_test.exs
+++ b/test/event_manager_web/integrations/event_test.exs
@@ -568,30 +568,63 @@ defmodule EventManagerWeb.Schema.EventTest do
   end
 
   describe "mutation eventAttend" do
-    @mutation """
-    mutation($eventId: ID!, $email: String) {
-      eventAttend(eventId: $eventId, email: $email) { #{@event_data} }
-    }
-    """
-
     test "accepts an email" do
+      mutation = """
+      mutation($eventId: ID!, $email: String) {
+        eventAttend(eventId: $eventId, email: $email) { #{@event_data} }
+      }
+      """
+
       event = event_fixture(status: :published)
       variables = %{"eventId" => event.id, "email" => "@"}
 
-      {:ok, result} = Absinthe.run(@mutation, @schema, variables: variables)
+      {:ok, result} = Absinthe.run(mutation, @schema, variables: variables)
 
       assert %{
-          data: %{
-            "eventAttend" => %{
-              "description" => description,
-              "endTime" => end_time,
-              "location" => location,
-              "startTime" => start_time,
-              "status" => "PUBLISHED",
-              "title" => title
-            }
-          }
-        } = result
+               data: %{
+                 "eventAttend" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "PUBLISHED",
+                   "title" => title
+                 }
+               }
+             } = result
+
+      assert description == event.description
+      assert end_time == event.end_time |> DateTime.to_iso8601()
+      assert location == event.location
+      assert start_time == event.start_time |> DateTime.to_iso8601()
+      assert title == event.title
+    end
+
+    test "accepts a user" do
+      mutation = """
+      mutation($eventId: ID!) {
+        eventAttend(eventId: $eventId) { #{@event_data} }
+      }
+      """
+
+      context = current_user()
+      event = event_fixture(status: :published)
+      variables = %{"eventId" => event.id}
+
+      {:ok, result} = Absinthe.run(mutation, @schema, variables: variables, context: context)
+
+      assert %{
+               data: %{
+                 "eventAttend" => %{
+                   "description" => description,
+                   "endTime" => end_time,
+                   "location" => location,
+                   "startTime" => start_time,
+                   "status" => "PUBLISHED",
+                   "title" => title
+                 }
+               }
+             } = result
 
       assert description == event.description
       assert end_time == event.end_time |> DateTime.to_iso8601()


### PR DESCRIPTION
Add the `eventAttend` mutation, that acceps an optional *email* or picks up the *current user*.